### PR TITLE
Add out-of-the-box support for date formats used by HTTP/1.1

### DIFF
--- a/Code/RKValueTransformers.m
+++ b/Code/RKValueTransformers.m
@@ -542,7 +542,17 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
             [RKDefaultValueTransformer addValueTransformer:[self iso8601TimestampToDateValueTransformer]];
             [RKDefaultValueTransformer addValueTransformer:[self timeIntervalSince1970ToDateValueTransformer]];
 
-            NSArray *defaultDateFormatStrings = @[ @"MM/dd/yyyy", @"yyyy-MM-dd" ];
+            // The latter three date format strings below represent the three
+            // date formats specified by the HTTP/1.1 protocol.  See
+            // http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
+            // for details
+            NSArray *defaultDateFormatStrings = @[
+                                                  @"MM/dd/yyyy",
+                                                  @"yyyy-MM-dd",
+                                                  @"EEE, dd MMM yyyy HH:mm:ss zzz", // RFC 1123
+                                                  @"EEEE, dd-MMM-yy HH:mm:ss zzz", // RFC 850
+                                                  @"EEE MMM d HH:mm:ss yyyy" // ANSI C asctime()
+                                                  ];
             for (NSString *dateFormatString in defaultDateFormatStrings) {
                 NSDateFormatter *dateFormatter = [NSDateFormatter new];
                 dateFormatter.dateFormat = dateFormatString;


### PR DESCRIPTION
Adds support for RFC 1123, RFC 850, and ANSI C asctime() date formats
Details: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1

The primary use case for this is for RestKit applications to be able to set a mapping from `@"@metadata.HTTP.response.headers.date"` to an `NSDate` instance. This doesn't currently work out of the box because the date formats supported by the HTTP protocol (see link above) aren't among the default value transformers.
