### PR TITLE
Add a cache in RKCompoundValueTransformer

### DIFF
--- a/Code/RKValueTransformers.m
+++ b/Code/RKValueTransformers.m
@@ -645,7 +645,7 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
     return self;
 }
 
-- (void)clearCache
+- (void)invalidateCache
 {
     dispatch_barrier_sync(self.cacheQueue, ^{
         [self.transformerCache removeAllObjects];
@@ -661,14 +661,14 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
 {
     if (! valueTransformer) [NSException raise:NSInvalidArgumentException format:@"Cannot add `nil` to a compound transformer."];
     [self.valueTransformers addObject:valueTransformer];
-    [self clearCache];
+    [self invalidateCache];
 }
 
 - (void)removeValueTransformer:(id<RKValueTransforming>)valueTransformer
 {
     if (! valueTransformer) [NSException raise:NSInvalidArgumentException format:@"Cannot remove `nil` from a compound transformer."];
     [self.valueTransformers removeObject:valueTransformer];
-    [self clearCache];
+    [self invalidateCache];
 }
 
 - (void)insertValueTransformer:(id<RKValueTransforming>)valueTransformer atIndex:(NSUInteger)index
@@ -694,8 +694,7 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
         transformers = [[[self transformerCache] objectForKey:(id)sourceClass] objectForKey:(id)destinationClass];
     });
 
-    if (transformers != nil)
-        return transformers;
+    if (transformers != nil) return transformers;
 
     NSMutableArray *matchingTransformers = [NSMutableArray arrayWithCapacity:[self.valueTransformers count]];
     for (RKValueTransformer *valueTransformer in self) {


### PR DESCRIPTION
This PR adds a cache in RKCompoundValueTransformer for source/destination class pairs, so that the subset of matching transformers does not have to be calculated every time.  This is a significant time savings while mapping.

This is the largest bottleneck I came across while looking into performance issues noted at https://github.com/RestKit/RestKit/issues/2065 .  When using the test application posted at https://github.com/rtimpone/restkit_relationship_mapping_benchmarking , I get the following timings on my device (an iPad 3) and iOS simulator (timings in seconds):

(Device) Mapping 5000 students with relationship mapping: 54.088767
(Simulator) Mapping 5000 students with relationship mapping: 7.312836

After applying this fix, the results are now more like:

(Device) Mapping 5000 students with relationship mapping: 43.592469
(Simulator) Mapping 5000 students with relationship mapping: 5.629380

I did play with using pthread_rw_locks, and the performance was comparable.  dispatch queues were more variable, but the average seemed about the same, so I left in the queue implementation.  A \@synchonized block was also similar, but that becomes more of a contention point if there are concurrent mapping operations, since the default RKCompoundValueTransformer is shared.

This was one of the bottlenecks mentioned at http://stackoverflow.com/questions/25431010/restkit-nested-one-to-many-relationship-mapping-is-very-slow , so others have noticed it too.
