### PR TITLE
Avoid creating error userInfo dictionaries when not needed

### DIFF
--- a/Code/RKValueTransformers.h
+++ b/Code/RKValueTransformers.h
@@ -96,8 +96,10 @@ typedef NS_ENUM(NSUInteger, RKValueTransformationError) {
         success = [inputValue isKindOfClass:expectedArgument]; \
     } \
     if (! success) { \
-        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `inputValue` of type `%@`, but got a `%@`.", expectedArgument, [inputValue class]] };\
-        if (error) *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo]; \
+        if (error) { \
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `inputValue` of type `%@`, but got a `%@`.", expectedArgument, [inputValue class]] };\
+            *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorUntransformableInputValue userInfo:userInfo]; \
+        } \
         return NO; \
     } \
 })
@@ -125,8 +127,10 @@ typedef NS_ENUM(NSUInteger, RKValueTransformationError) {
         success = [outputValueClass isSubclassOfClass:expectedArgument]; \
     } \
     if (! success) { \
-        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `outputValueClass` of type `%@`, but got a `%@`.", expectedArgument, outputValueClass] };\
-        if (error) *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorUnsupportedOutputClass userInfo:userInfo]; \
+        if (error) { \
+            NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected an `outputValueClass` of type `%@`, but got a `%@`.", expectedArgument, outputValueClass] };\
+            *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorUnsupportedOutputClass userInfo:userInfo]; \
+        } \
         return NO; \
     } \
 })
@@ -143,10 +147,12 @@ typedef NS_ENUM(NSUInteger, RKValueTransformationError) {
  */
 #define RKValueTransformerTestTransformation(condition, error, ...) ({ \
 if (! (condition)) { \
-    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:__VA_ARGS__] };\
-    if (error) *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo]; \
-        return NO; \
+    if (error) { \
+        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:__VA_ARGS__] };\
+        *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo]; \
     } \
+    return NO; \
+  } \
 })
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Make the value-checking macros avoid creating an error userInfo dictionary if the error is not going to be created (i.e. the given error reference pointer is NULL).

I had thought of an approach for RKCompoundValueTransformer to first go through the list with a NULL error parameter to see if any of the transformers can successfully convert a value, and if not then go back through all of them and collect the error instances.  Right now if some initial transformers fail, the errors and containing array are all created, but will be thrown away if a subsequent valueTransformer succeeds.  This approach would be the same as before if the first transformer succeeds, faster if only subsequent transforms succeed, and slower on failures.  I did not have a decent test app for this scenario though so I don't know how much it would help in practice.  So, just leaving this PR with the macro changes, which do help if NULL is passed (which RestKit almost never does, outside of RKObjectParameterization).
