### PR TITLE
Fix RKCompoundValueTransformer memory leak

### DIFF
--- a/Code/RKValueTransformers.m
+++ b/Code/RKValueTransformers.m
@@ -702,6 +702,14 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
     return self;
 }
 
+- (void)dealloc
+{
+#if !OS_OBJECT_USE_OBJC
+    if (_cacheQueue) dispatch_release(_cacheQueue);
+#endif
+    _cacheQueue = NULL;
+}
+
 - (void)invalidateCache
 {
     dispatch_barrier_sync(self.cacheQueue, ^{


### PR DESCRIPTION
Closes RestKit/RestKit#2112.

If the iOS deployment target is before version 6.0, the recent change to RKCompoundValueTransformer would leak a dispatch queue.  I should have had a conditional dispatch_queue_release in the dealloc method.  Broken in #14.
