### PR TITLE
Fixed issue with if statement checking for errors

### DIFF
--- a/Code/RKValueTransformers.m
+++ b/Code/RKValueTransformers.m
@@ -833,7 +833,7 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
         [errors addObject:underlyingError];
     }
 
-    if (error) {
+    if (errors.count > 0) {
         errors = errors ?: (id)[NSArray new];
         NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed transformation of value '%@' to %@: none of the %lu value transformers consulted were successful.", inputValue, outputValueClass, (unsigned long)[matchingTransformers count]], RKValueTransformersDetailedErrorsKey: errors };
         *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo];


### PR DESCRIPTION
Resolved Xcode analyze warning which is worried about "errors" being nil. Also looks like if the error was not the last object of the for loop, the userInfo would not be properly set