### PR TITLE
Fix recently-added RKCompoundValueTransformer errors

### DIFF
--- a/Code/RKValueTransformers.m
+++ b/Code/RKValueTransformers.m
@@ -823,7 +823,7 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
 - (BOOL)transformValue:(id)inputValue toValue:(__autoreleasing id *)outputValue ofClass:(__unsafe_unretained Class)outputValueClass error:(NSError *__autoreleasing *)error
 {
     NSArray *matchingTransformers = [self valueTransformersForTransformingFromClass:[inputValue class] toClass:outputValueClass];
-    NSMutableArray *errors;
+    NSMutableArray *errors = nil;
     NSError *underlyingError = nil;
     for (id<RKValueTransforming> valueTransformer in matchingTransformers) {
         BOOL success = [valueTransformer transformValue:inputValue toValue:outputValue ofClass:outputValueClass error:&underlyingError];
@@ -832,9 +832,9 @@ static dispatch_once_t RKDefaultValueTransformerOnceToken;
         [errors addObject:underlyingError];
     }
 
-    if (errors.count > 0) {
-        errors = errors ?: (id)[NSArray new];
-        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed transformation of value '%@' to %@: none of the %lu value transformers consulted were successful.", inputValue, outputValueClass, (unsigned long)[matchingTransformers count]], RKValueTransformersDetailedErrorsKey: errors };
+    if (error) {
+        NSArray *detailedErrors = errors ?: [NSArray new];
+        NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Failed transformation of value '%@' to %@: none of the %lu value transformers consulted were successful.", inputValue, outputValueClass, (unsigned long)[matchingTransformers count]], RKValueTransformersDetailedErrorsKey: detailedErrors };
         *error = [NSError errorWithDomain:RKValueTransformersErrorDomain code:RKValueTransformationErrorTransformationFailed userInfo:userInfo];
     }
     return NO;

--- a/Tests/RKValueTransformersTests.m
+++ b/Tests/RKValueTransformersTests.m
@@ -1411,6 +1411,31 @@ static RKBlockValueTransformer *RKTestValueTransformerWithOutputValue(id staticO
     expect(error.localizedDescription).to.equal(@"Failed transformation of value '2' to NSString: none of the 1 value transformers consulted were successful.");
 }
 
+- (void)testTransformingErrorWithoutDetailedErrors
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    NSString *outputValue;
+    NSError *error = nil;
+    BOOL success = [compoundValueTransformer transformValue:@"2" toValue:&outputValue ofClass:[NSString class] error:&error];
+    expect(success).to.beFalsy();
+    expect(outputValue).to.beNil();
+    expect(error.code).to.equal(RKValueTransformationErrorTransformationFailed);
+}
+
+- (void)testTransformingErrorWithNullErrorParameter
+{
+    RKCompoundValueTransformer *compoundValueTransformer = [RKCompoundValueTransformer new];
+    [compoundValueTransformer addValueTransformer:[RKBlockValueTransformer valueTransformerWithValidationBlock:nil transformationBlock:^BOOL(id inputValue, __autoreleasing id *outputValue, __unsafe_unretained Class outputClass, NSError *__autoreleasing *error) {
+        // Always fails
+        RKValueTransformerTestTransformation(NO, error, @"This is an underlying error.");
+        return YES;
+    }]];
+    NSString *outputValue;
+    BOOL success = [compoundValueTransformer transformValue:@"2" toValue:&outputValue ofClass:[NSString class] error:NULL];
+    expect(success).to.beFalsy();
+    expect(outputValue).to.beNil();
+}
+
 #pragma mark NSCopying
 
 - (void)testCopying


### PR DESCRIPTION
The #21 change (which was just trying to silence an analyzer warning, which is either a bug in the analyzer or maybe an uninitialized variable) introduced a pair of bugs.  Revert the change (adding test cases for the bugs), and try a different approach to silencing the analyzer (I am not using Xcode 6.3, so not sure if it actually works).

Both bugs are unlikely to occur with RestKit usage (doesn't pass NULL for the error parameter, and the identity transformer should basically always mean there is a non-empty transformer list), but the situations should work correctly in case the code is used in other ways.